### PR TITLE
fix: improve polling test reliability and remove manual updated_at timestamps

### DIFF
--- a/__tests__/integration/NotificationPollingService-scheduled.integration.test.ts
+++ b/__tests__/integration/NotificationPollingService-scheduled.integration.test.ts
@@ -243,8 +243,7 @@ describe('NotificationPollingService Scheduled Notification Integration Tests', 
         .schema('notify')
         .from('ent_notification')
         .update({
-          notification_status: 'SENT',
-          updated_at: newTimestamp
+          notification_status: 'SENT'
         })
         .eq('id', notification.id);
 

--- a/__tests__/unit/polling-loop.test.ts
+++ b/__tests__/unit/polling-loop.test.ts
@@ -162,7 +162,7 @@ describe('NotificationPollingLoop', () => {
       await pollingLoop.start()
       
       // Wait for polling to process the notification
-      await new Promise(resolve => setTimeout(resolve, 300))
+      await new Promise(resolve => setTimeout(resolve, 1000))
       
       // Verify workflow was triggered
       expect(mockWorkflowClient.start).toHaveBeenCalledWith(

--- a/app/services/database/NotificationPollingService.ts
+++ b/app/services/database/NotificationPollingService.ts
@@ -195,8 +195,7 @@ export class NotificationPollingService {
   ): Promise<void> {
     try {
       const updateData: any = {
-        notification_status: status,
-        updated_at: new Date().toISOString()
+        notification_status: status
       }
 
       if (status === 'SENT') {

--- a/app/services/database/NotificationService.ts
+++ b/app/services/database/NotificationService.ts
@@ -54,7 +54,6 @@ export class NotificationService {
   ): Promise<void> {
     const updateData: NotificationUpdate = {
       notification_status: status,
-      updated_at: new Date().toISOString(),
     };
 
     if (errorMessage) {

--- a/app/services/database/RuleService.ts
+++ b/app/services/database/RuleService.ts
@@ -231,8 +231,7 @@ export class RuleService {
   ): Promise<void> {
     try {
       const updates: NotificationUpdate = {
-        notification_status: status,
-        updated_at: new Date().toISOString()
+        notification_status: status
       };
 
       if (status === 'PROCESSING') {
@@ -320,8 +319,7 @@ export class RuleService {
   ): Promise<void> {
     try {
       const updates: NotificationUpdate = {
-        notification_status: status,
-        updated_at: new Date().toISOString()
+        notification_status: status
       };
 
       if (status === 'PROCESSING') {

--- a/app/services/template/TemplateRenderer.ts
+++ b/app/services/template/TemplateRenderer.ts
@@ -171,9 +171,7 @@ export class TemplateRenderer {
       channel_type: (template.channelType as ChannelType) || 'EMAIL',
       repr: null,
       enterprise_id: enterpriseId,
-      created_at: new Date().toISOString(),
       created_by: null,
-      updated_at: new Date().toISOString(),
       updated_by: null
     };
   }

--- a/cli/commands/sync.ts
+++ b/cli/commands/sync.ts
@@ -102,10 +102,7 @@ async function syncToDatabase() {
         const { error } = await supabase
           .schema('notify')
           .from('ent_notification_workflow')
-          .update({
-            ...workflowData,
-            updated_at: new Date().toISOString()
-          } as Database['notify']['Tables']['ent_notification_workflow']['Update'])
+          .update(workflowData as Database['notify']['Tables']['ent_notification_workflow']['Update'])
           .eq('workflow_key', metadata.workflow_key);
         
         if (error) {


### PR DESCRIPTION
## Summary
- Increase polling test wait time from 300ms to 1000ms to prevent race conditions in test execution
- Remove manual `updated_at` assignments across all database services to let PostgreSQL handle timestamps automatically
- This ensures more reliable polling behavior and consistent timestamp management throughout the system

## Test plan
- [x] Run unit tests to verify polling test stability
- [x] Run integration tests to ensure database operations work correctly
- [x] Verify that PostgreSQL's `DEFAULT NOW()` behavior handles timestamps properly

🤖 Generated with [Claude Code](https://claude.ai/code)