### PR TITLE
fix: replace require() with ES module import in next.config.mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,10 @@
+import { cpus } from 'os';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
   experimental: {
-    cpus: require('os').cpus().length,
+    cpus: cpus().length,
     workerThreads: false,
   },
 };


### PR DESCRIPTION
## Summary
• Fixed ESLint error in next.config.mjs where require('os') was used in an ES module context
• Replaced with proper ES module import syntax: import { cpus } from 'os'

## Test plan
- [x] Verified lint passes with `pnpm lint`
- [x] No other changes needed

🤖 Generated with [Claude Code](https://claude.ai/code)