### PR TITLE
perf: parallelize CI test execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  # First job: Setup, lint, and connection tests
+  setup-and-validate:
     runs-on: self-hosted
     environment: Test
 
@@ -69,7 +70,6 @@ jobs:
       run: pnpm test:connection
       env:
         CI: true
-        # Connection test credentials
         NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
         NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -79,13 +79,58 @@ jobs:
         TEMPORAL_ADDRESS: ${{ secrets.TEMPORAL_ADDRESS }}
         TEMPORAL_NAMESPACE: ${{ secrets.TEMPORAL_NAMESPACE }}
         TEMPORAL_TASK_QUEUE: ${{ secrets.TEMPORAL_TASK_QUEUE }}
+
+    # Cache the node_modules for other jobs
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          ~/.pnpm-store
+          .next
+        key: deps-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+  # Second job: Unit tests (runs after setup-and-validate)
+  unit-tests:
+    needs: setup-and-validate
+    runs-on: self-hosted
+    environment: Test
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'pnpm'
+        registry-url: 'http://172.20.60.129:4873'
+
+    - name: Restore cached dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          ~/.pnpm-store
+          .next
+        key: deps-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+    - name: Configure pnpm registry
+      run: pnpm config set registry http://172.20.60.129:4873
+
+    - name: Install dependencies (if cache miss)
+      run: pnpm install --frozen-lockfile
 
     - name: Run unit tests
       run: pnpm test:unit
       env:
         CI: true
         NODE_ENV: test
-        # Connection test credentials
         NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
         NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -95,13 +140,61 @@ jobs:
         TEMPORAL_ADDRESS: ${{ secrets.TEMPORAL_ADDRESS }}
         TEMPORAL_NAMESPACE: ${{ secrets.TEMPORAL_NAMESPACE }}
         TEMPORAL_TASK_QUEUE: ${{ secrets.TEMPORAL_TASK_QUEUE }}
+
+    - name: Upload unit test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: unit-test-results
+        path: |
+          coverage/unit/
+          junit-unit.xml
+        retention-days: 7
+
+  # Third job: Integration tests (runs after setup-and-validate, parallel to unit-tests)
+  integration-tests:
+    needs: setup-and-validate
+    runs-on: self-hosted
+    environment: Test
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'pnpm'
+        registry-url: 'http://172.20.60.129:4873'
+
+    - name: Install Temporal CLI
+      uses: temporalio/setup-temporal@v0
+
+    - name: Restore cached dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          ~/.pnpm-store
+          .next
+        key: deps-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+    - name: Configure pnpm registry
+      run: pnpm config set registry http://172.20.60.129:4873
+
+    - name: Install dependencies (if cache miss)
+      run: pnpm install --frozen-lockfile
 
     - name: Run integration tests
       run: pnpm test:integration
       env:
         CI: true
         NODE_ENV: test
-        # Connection test credentials
         NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
         NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -112,12 +205,31 @@ jobs:
         TEMPORAL_NAMESPACE: ${{ secrets.TEMPORAL_NAMESPACE }}
         TEMPORAL_TASK_QUEUE: ${{ secrets.TEMPORAL_TASK_QUEUE }}
 
-    - name: Upload test results
+    - name: Upload integration test results
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: test-results
+        name: integration-test-results
         path: |
-          coverage/
-          junit.xml
+          coverage/integration/
+          junit-integration.xml
+        retention-days: 7
+
+  # Optional: Combine test results
+  combine-results:
+    needs: [unit-tests, integration-tests]
+    runs-on: self-hosted
+    if: always()
+
+    steps:
+    - name: Download all test results
+      uses: actions/download-artifact@v4
+      with:
+        path: test-results/
+
+    - name: Upload combined test results
+      uses: actions/upload-artifact@v4
+      with:
+        name: all-test-results
+        path: test-results/
         retention-days: 7


### PR DESCRIPTION
## Summary
- Split monolithic test job into three parallel jobs for improved CI performance
- Separated unit and integration tests to run concurrently after initial setup
- Implemented proper dependency caching between jobs to avoid redundant installations

## Test plan
- [x] Verify CI workflow syntax is valid
- [ ] Check that setup-and-validate job completes successfully
- [ ] Confirm unit-tests and integration-tests run in parallel
- [ ] Ensure proper caching works between jobs
- [ ] Validate test results are uploaded correctly

🤖 Generated with [Claude Code](https://claude.ai/code)